### PR TITLE
Fix tuple assignment issue and PEP-8 style

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,14 @@
 Python port of the extended Node.js EventEmitter 2 approach of
 https://github.com/asyncly/EventEmitter2 providing namespaces, wildcards and TTL.
 
-#### Features
+## Features
 
 - Namespaces with wildcards
 - Times to listen (TTL)
 - Usage via decorators or callbacks
 - Lightweight implementation, good performance
 
-
-#### Installation
+## Installation
 
 *pymitter* is a registered [PyPI module](https://pypi.python.org/pypi/pymitter), so the installation
 with *pip* is quite easy:
@@ -20,10 +19,9 @@ with *pip* is quite easy:
 pip install pymitter
 ```
 
-
 ## Examples
 
-#### Basic usage
+### Basic usage
 
 ```python
 from pymitter import EventEmitter
@@ -48,8 +46,7 @@ ee.emit("myotherevent", "bar")
 # -> "handler2 called with bar"
 ```
 
-
-#### TTL
+### TTL
 
 ```python
 from pymitter import EventEmitter
@@ -63,7 +60,7 @@ def handler1():
 @ee.on("myevent", ttl=10)
 def handler2():
     print "handler2 called"
-    
+
 
 ee.emit("myevent")
 # -> "handler1 called"
@@ -74,8 +71,7 @@ ee.emit("myevent")
 
 ```
 
-
-#### Wildcards
+### Wildcards
 
 ```python
 from pymitter import EventEmitter
@@ -109,10 +105,10 @@ ee.emit("myevent.*")
 # -> "handler3 called"
 ```
 
-
 ## API
 
-##### ``EventEmitter(wildcard=False, delimiter=".", new_listener=False, max_listeners=-1)``
+### ``EventEmitter(wildcard=False, delimiter=".", new_listener=False, max_listeners=-1)``
+
 EventEmitter constructor. **Note**: always use *kwargs* for configuration. When *wildcard* is
 *True*, wildcards are used as shown in [this example](#wildcards). *delimiter* is used to seperate
 namespaces within events. If *new_listener* is *True*, the *"new_listener"* event is emitted every
@@ -120,42 +116,41 @@ time a new listener is registered. Functions listening to this event are passed
 ``(func, event=None)``. *max_listeners* defines the maximum number of listeners per event. Negative
 values mean infinity.
 
-- ##### ``on(event, func=None, ttl=-1)``
+- #### ``on(event, func=None, ttl=-1)``
 	Registers a function to an event. When *func* is *None*, decorator usage is assumed. *ttl*
 	defines the times to listen. Negative values mean infinity. Returns the function.
 
-- ##### ``once(event, func=None)``
+- #### ``once(event, func=None)``
 	Registers a function to an event with ``ttl = 1``. When *func* is *None*, decorator usage is
 	assumed. Returns the function.
 
-- ##### ``on_any(func=None)``
+- #### ``on_any(func=None)``
 	Registers a function that is called every time an event is emitted. When *func* is *None*,
 	decorator usage is assumed. Returns the function.
 
-- ##### ``off(event, func=None)``
+- #### ``off(event, func=None)``
 	Removes a function that is registered to an event. When *func* is *None*, decorator usage is
 	assumed. Returns the function.
 
-- ##### ``off_any(func=None)``
+- #### ``off_any(func=None)``
 	Removes a function that was registered via ``on_any()``. When *func* is *None*, decorator usage
 	is assumed. Returns the function.
 
-- ##### ``off_all()``
+- #### ``off_all()``
 	Removes all functions of all events.
 
-- ##### ``listeners(event)``
+- #### ``listeners(event)``
 	Returns all functions that are registered to an event. Wildcards are not applied.
 
-- ##### ``listeners_any()``
+- #### ``listeners_any()``
 	Returns all functions that were registered using ``on_any()``.
 
-- ##### ``listeners_all()``
+- #### ``listeners_all()``
 	Returns all registered functions.
 
-- ##### ``emit(event, *args, **kwargs)``
+- #### ``emit(event, *args, **kwargs)``
 	Emits an event. All functions of events that match *event* are invoked with *args* and *kwargs*
 	in the exact order of their registeration. Wildcards might be applied.
-
 
 ## Development
 
@@ -163,7 +158,6 @@ values mean infinity.
 - Python module hostet at [PyPI](https://pypi.python.org/pypi/pymitter)
 - Report issues, questions, feature requests on
   [GitHub Issues](https://github.com/riga/pymitter/issues)
-
 
 ## License
 
@@ -188,7 +182,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
 
 ## Authors
 

--- a/pymitter/__init__.py
+++ b/pymitter/__init__.py
@@ -18,7 +18,7 @@ __credits__ = ["Marcel Rieger"]
 __license__ = "MIT"
 __maintainer__ = "Marcel Rieger"
 __status__ = "Development"
-__version__ = "0.2.4"
+__version__ = "0.2.3"
 __all__ = ["EventEmitter"]
 
 

--- a/pymitter/__init__.py
+++ b/pymitter/__init__.py
@@ -8,43 +8,45 @@ Python port of the extended Node.js EventEmitter 2 approach providing
 namespaces, wildcards and TTL.
 """
 
-
-__author__     = "Marcel Rieger"
-__copyright__  = "Copyright 2014, Marcel Rieger"
-__credits__    = ["Marcel Rieger"]
-__license__    = "MIT"
-__maintainer__ = "Marcel Rieger"
-__status__     = "Development"
-__version__    = "0.2.3"
-__all__        = ["EventEmitter"]
-
-
 # python imports
 from time import time
 
 
+__author__ = "Marcel Rieger"
+__copyright__ = "Copyright 2014, Marcel Rieger"
+__credits__ = ["Marcel Rieger"]
+__license__ = "MIT"
+__maintainer__ = "Marcel Rieger"
+__status__ = "Development"
+__version__ = "0.2.4"
+__all__ = ["EventEmitter"]
+
+
 class EventEmitter(object):
 
-    __CBKEY  = "__callbacks"
+    __CBKEY = "__callbacks"
     __WCCHAR = "*"
 
     def __init__(self, **kwargs):
-        """ EventEmitter(wildcard=False, delimiter=".", new_listener=False,
-                         max_listeners=-1)
+        """
+        EventEmitter(wildcard=False, delimiter=".", new_listener=False,
+        max_listeners=-1)
+
         The EventEmitter class.
         Please always use *kwargs* in the constructor.
         - *wildcard*: When *True*, wildcards are used.
-        - *delimiter*: The delimiter to seperate event namespaces.
-        - *new_listener*: When *True*, the "new_listener" event is emitted every
-          time a new listener is registered with arguments *(func, event=None)*.
-        - *max_listeners*: Maximum number of listeners per event. Negativ values
-          mean infinity.
+        - *delimiter*: The delimiter to separate event namespaces.
+        - *new_listener*: When *True*, the "new_listener" event is emitted
+          every time a new listener is registered with arguments
+          *(func, event=None)*.
+        - *max_listeners*: Maximum number of listeners per event. Negative
+          values mean infinity.
         """
         super(EventEmitter, self).__init__()
 
-        self.wildcard      = kwargs.get("wildcard", False)
-        self.__delimiter   = kwargs.get("delimiter", ".")
-        self.new_listener  = kwargs.get("new_listener", False)
+        self.wildcard = kwargs.get("wildcard", False)
+        self.__delimiter = kwargs.get("delimiter", ".")
+        self.new_listener = kwargs.get("new_listener", False)
         self.max_listeners = kwargs.get("max_listeners", -1)
 
         self.__tree = self.__new_branch()
@@ -63,11 +65,11 @@ class EventEmitter(object):
         a special item *__CBKEY* that holds registered functions. All other
         items are used to build a tree structure.
         """
-        return { cls.__CBKEY: [] }
+        return {cls.__CBKEY: []}
 
     def __find_branch(self, event):
         """
-        Returns a branch of the tree stucture that matches *event*. Wildcards
+        Returns a branch of the tree structure that matches *event*. Wildcards
         are not applied.
         """
         parts = event.split(self.delimiter)
@@ -139,7 +141,7 @@ class EventEmitter(object):
         function.
         """
         if len(args) == 3:
-            args[2] = 1
+            args = (args[0], args[1], 1)
         else:
             kwargs["ttl"] = 1
         return self.on(*args, **kwargs)
@@ -147,7 +149,8 @@ class EventEmitter(object):
     def on_any(self, func=None):
         """
         Registers a function that is called every time an event is emitted.
-        When *func* is *None*, decorator usage is assumed. Returns the function.
+        When *func* is *None*, decorator usage is assumed. Returns the
+        function.
         """
         def _on_any(func):
             if not hasattr(func, "__call__"):
@@ -207,15 +210,15 @@ class EventEmitter(object):
 
     def off_all(self):
         """
-        Removes all registerd functions.
+        Removes all registered functions.
         """
         del self.__tree
         self.__tree = self.__new_branch()
 
     def listeners(self, event):
         """
-        Returns all functions that are registered to an event. Wildcards are not
-        applied.
+        Returns all functions that are registered to an event. Wildcards are
+        not applied.
         """
         branch = self.__find_branch(event)
         if branch is None:
@@ -290,14 +293,14 @@ class Listener(object):
     def __init__(self, func, event, ttl):
         """
         The Listener class.
-        Listener instances are simple structs to handle functions and their ttl
-        values.
+        Listener instances are simple structures to handle functions and their
+        ttl values.
         """
         super(Listener, self).__init__()
 
-        self.func  = func
+        self.func = func
         self.event = event
-        self.ttl   = ttl
+        self.ttl = ttl
 
         self.time = time()
 

--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,18 @@ from distutils.core import setup
 
 
 setup(
-    name         = "pymitter",
-    version      = "0.2.3",
-    packages     = ["pymitter"],
-    description  = "Python port of the extended Node.js EventEmitter 2 "
-                   "approach providing namespaces, wildcards and TTL.",
-    author       = "Marcel Rieger",
-    author_email = "marcelrieger@icloud.com",
-    url          = "https://github.com/riga/pymitter",
-    keywords     = [
+    name="pymitter",
+    version="0.2.4",
+    packages=["pymitter"],
+    description="Python port of the extended Node.js EventEmitter 2 "
+                "approach providing namespaces, wildcards and TTL.",
+    author="Marcel Rieger",
+    author_email="marcelrieger@icloud.com",
+    url="https://github.com/riga/pymitter",
+    keywords=[
         "event", "emitter", "eventemitter", "wildcard", "node", "nodejs"
     ],
-    classifiers  = [
+    classifiers=[
         "Programming Language :: Python",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -25,7 +25,7 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3"
     ],
-    long_description = """\
+    long_description="""\
 pymitter
 ========
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.core import setup
 
 setup(
     name="pymitter",
-    version="0.2.4",
+    version="0.2.3",
     packages=["pymitter"],
     description="Python port of the extended Node.js EventEmitter 2 "
                 "approach providing namespaces, wildcards and TTL.",

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -12,9 +12,10 @@ import unittest
 base = os.path.normpath(os.path.join(os.path.abspath(__file__), "../.."))
 sys.path.append(base)
 
-
 # local imports
 from pymitter import EventEmitter
+
+sys.path.remove(base)
 
 
 class AllTestCase(unittest.TestCase):
@@ -47,17 +48,39 @@ class AllTestCase(unittest.TestCase):
         self.ee1.emit("1_decorator_usage", "bar")
         self.assertTrue(self.stack[-1] == "1_decorator_usage_bar")
 
-    def test_1_ttl(self):
-        # same as once
-        @self.ee1.on("1_ttl", ttl=1)
+    def test_1_ttl_on(self):
+        # Same as once.
+        @self.ee1.on("1_ttl_on", ttl=1)
         def handler(arg):
-            self.stack.append("1_ttl_" + arg)
+            self.stack.append("1_ttl_on_" + arg)
 
-        self.ee1.emit("1_ttl", "foo")
-        self.assertTrue(self.stack[-1] == "1_ttl_foo")
+        self.ee1.emit("1_ttl_on", "foo")
+        self.assertTrue(self.stack[-1] == "1_ttl_on_foo")
 
-        self.ee1.emit("1_ttl", "bar")
-        self.assertTrue(self.stack[-1] == "1_ttl_foo")
+        self.ee1.emit("1_ttl_on", "bar")
+        self.assertTrue(self.stack[-1] == "1_ttl_on_foo")
+
+    def test_1_ttl_once(self):
+        @self.ee1.once("1_ttl_once")
+        def handler(arg):
+            self.stack.append("1_ttl_once_" + arg)
+
+        self.ee1.emit("1_ttl_once", "foo")
+        self.assertTrue(self.stack[-1] == "1_ttl_once_foo")
+
+        self.ee1.emit("1_ttl_once", "bar")
+        self.assertTrue(self.stack[-1] == "1_ttl_once_foo")
+
+    def test_1_once_should_fix_ttl(self):
+        @self.ee1.once("1_ttl_once_fix", None, 2)
+        def handler(arg):
+            self.stack.append("1_ttl_once_fix_" + arg)
+
+        self.ee1.emit("1_ttl_once_fix", "foo")
+        self.assertTrue(self.stack[-1] == "1_ttl_once_fix_foo")
+
+        self.ee1.emit("1_ttl_once_fix", "bar")
+        self.assertTrue(self.stack[-1] == "1_ttl_once_fix_foo")
 
     def test_2_on_all(self):
         @self.ee2.on("2_on_all.*")


### PR DESCRIPTION
Hello!

I searched for a simple and lightweight event system and found your awesome library. However, I found a bug in  `EventEmitter` implementation. This PR contains bugfix and styles improvement (PEP-8, markdown).

As for bug, I encountered it in the implementation of `once` function:

```py
    def once(self, *args, **kwargs):
        """
        Registers a function to an event with *ttl = 1*. See *on*. Returns the
        function.
        """
        if len(args) == 3:
            args[2] = 1  # ERROR: tuple does not support item assignment.
        else:
            kwargs["ttl"] = 1
        return self.on(*args, **kwargs)

```

This function contains wrong statement: `args[2] = 1` which can lead to error "Tuple does not support item assignment" (because it is immutable). I replaced it with the following statement: `args = (args[0], args[1], 1)`. Here we create new tuple based on the old one with new TTL value.

In addition, I incremented package version to 0.2.4 and add several tests to ensure that bug was fixed.

I hope you find this PR useful :)
