### PR TITLE
Fix typo of named argument in documentation of wildcard example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ ee.emit("myevent")
 from pymitter import EventEmitter
 
 
-ee = EventEmitter(wildcards=True)
+ee = EventEmitter(wildcard=True)
 
 
 @ee.on("myevent.foo")


### PR DESCRIPTION
The wildcard example does not function as it stands, but the issue is a simple typo of an additional 's'. This fixes it.