### PR TITLE
Support async callable classes

### DIFF
--- a/pymitter/__init__.py
+++ b/pymitter/__init__.py
@@ -193,7 +193,7 @@ class EventEmitter(object):
                 self.off(listener.event, func=listener.func)
 
             res = listener(*args, **kwargs)
-            if listener.is_coroutine:
+            if listener.is_coroutine or listener.is_async_callable:
                 awaitables.append(res)
 
         return awaitables
@@ -409,6 +409,10 @@ class Listener(object):
     @property
     def is_coroutine(self: Listener) -> bool:
         return asyncio.iscoroutinefunction(self.func)
+
+    @property
+    def is_async_callable(self):
+        return hasattr(self.func, "__call__") and asyncio.iscoroutinefunction(self.func.__call__)
 
     def __call__(self: Listener, *args, **kwargs) -> Any:
         """

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -398,3 +398,16 @@ if sys.version_info[:2] >= (3, 8):
                 self.assertEqual(tuple(stack), ("emit_future_bar",))
 
             await test()
+
+        def test_supports_async_callables(self):
+            ee = EventEmitter()
+            stack = []
+
+            class EventHandler:
+                async def __call__(self, arg):
+                    stack.append(arg)
+
+            ee.on("event", EventHandler())
+
+            ee.emit("event", "arg")
+            self.assertEqual(stack, ["arg"])


### PR DESCRIPTION
Hello! I'd like to use pymitter with async callable classes, like this.

```python
class EventHandler:
    def __init__(self, dep1, dep2):  # Injected dependencies.
        self.dep1 = dep1
        self.dep2 = dep2

    async def __call__(self, arg):
        ...

ee.on("event", EventHandler(dep1, dep2))
```

It's not possible right now, due to the way `pymitter` checks if an event handler is async using `asyncio.iscoroutinefunction`. I've added another check that works with such callables.  `pyee` supports this usecase, but sadly it lacks wildcard dispatching.