### PR TITLE
Make pymitter type-safe

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,7 @@
 max-line-length = 101
 
 # codes of errors to ignore
-ignore = E128, E306, E402, E722, E731, W504
+ignore = E128, E306, E402, E722, E731, W504, E704
 
 # enforce double quotes
 inline-quotes = double

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -57,6 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/pymitter/__init__.py
+++ b/pymitter/__init__.py
@@ -26,7 +26,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 T = TypeVar("T")
 
 
-class EventEmitter(object):
+class EventEmitter:
     """
     The EventEmitter class, ported from Node.js EventEmitter 2.
 
@@ -48,8 +48,6 @@ class EventEmitter(object):
         new_listener: bool = False,
         max_listeners: int = -1,
     ) -> None:
-        super().__init__()
-
         # store attributes
         self.new_listener = new_listener
         self.max_listeners = max_listeners
@@ -267,10 +265,8 @@ class EventEmitter(object):
             asyncio.ensure_future(asyncio.gather(*awaitables))
 
 
-class BaseNode(object):
+class BaseNode:
     def __init__(self, wildcard: bool, delimiter: str) -> None:
-        super().__init__()
-
         self.wildcard = wildcard
         self.delimiter = delimiter
         self.parent: "Optional[BaseNode]" = None
@@ -418,15 +414,13 @@ class Tree(BaseNode):
         return listeners
 
 
-class Listener(object):
+class Listener:
     """
     A simple event listener class that wraps a function *func* for a specific *event* and that keeps
     track of the times to listen left.
     """
 
     def __init__(self, func: Callable[..., Any], event: str, ttl: int) -> None:
-        super().__init__()
-
         self.func = func
         self.event = event
         self.ttl = ttl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,6 @@ dependencies = {file = ["requirements.txt"]}
 optional-dependencies = {dev = {file = ["requirements_dev.txt"]}}
 
 
-[tool.setuptools]
-
-include-package-data = false
-
-
 [tool.setuptools.packages.find]
 
 include = ["pymitter"]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,8 @@
-mypy~=1.9.0;python_version>="3.8"
 flake8~=7.0.0;python_version>="3.8"
 flake8~=5.0.0;python_version<"3.8"
 flake8-commas~=2.1.0
 flake8-quotes~=3.3.2
 types-docutils~=0.20.0
 pytest-cov>=3.0
+mypy>=1.4.1
+typing-extensions>=4.7.1


### PR DESCRIPTION
Hey! I'm using pymitter in a couple of projects and I'm really missing the type hints. So this is my attempt to fix this problem.

What I did:
1. I tried to make pymitter as type-safe as I could, except for `Tree.add_listener` method, where I had to leave some `type: ignore` directives. I believe it is fixable, but requires some refactoring.
2. I made `mypy` checks compatible with Python 3.7, so I've extended the test matrix.  
3. I added a `py.typed` marker file, which is required for type hinted packages.
4. I've also included a refactoring commit to get rid of the `object` inheritance (which isn't required, I believe, since Python 3).

Please note that I had to introduce a breaking change - the `ttl` parameter of `on` and `on_any` methods had to become a keyword argument, breaking callers who pass it as a positional argument. This way I could make use of `@overload` to more accurately describe signatures both for decorated and non-decorated usage.